### PR TITLE
[#98167932] 郵政の日時指定が取れなくなっていた不具合の修正

### DIFF
--- a/lib/tracker/api/corporations/yuusei.rb
+++ b/lib/tracker/api/corporations/yuusei.rb
@@ -105,25 +105,14 @@ module Tracker
                 build.status = t.css('td[@class="w_150"]').text # 配送履歴（ステータス）
                 build.description = t.css('td[@class="w_180"]').text # 詳細
                 build.place = t.css('td[@class="w_105"]')[0].text # 取扱局
+                build.planned_date = @planned_date
+                build.planned_time = @planned_time
                 @details << build.object_to_hash
               end
             end
           end
 
         end
-
-        self
-      end
-
-      def insert_latest_data
-        @build.company = "yuusei"
-        @build.date ||= Date.today.to_s
-        @build.time ||= Time.now.strftime("%H:%M:%S")
-        @build.status ||= ""
-        @build.place ||= ""
-        @build.planned_date = @planned_date
-        @build.planned_time = @planned_time
-        @details << @build.object_to_hash
 
         self
       end


### PR DESCRIPTION
[#97163300] 再修正 JSONの最初と最後に無効なエントリが入らないようにする のデグレ
郵政の場合JSONの最後の(無効な)エントリにのみ日時指定情報が保存されるようになっていた。
また、insert_latest_dataは使用されないので削除。
