### PR TITLE
The time library is required to call Time.parse

### DIFF
--- a/lib/tracker/api/formatter/time.rb
+++ b/lib/tracker/api/formatter/time.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module Tracker # :nodoc:
   module Api # :nodoc:
     class Formatter


### PR DESCRIPTION
This commit fixes the following error.

```
$ bundle exec bin/tracker trace -n xxx -c sagawa
input: xxx
output: [[{"no"=>"xxx",
   "company"=>"sagawa",
   "error"=>
    "class: NoMethodError, message: undefined method `parse' for Time:Class"}]]
shipping company: sagawa
```
